### PR TITLE
Improve transaction categorization UX and LLM integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
 import pandas as pd
-from utils import load_statements, load_existing_table, save_table
+from utils import load_existing_table, save_table
 from llm import categorize_expense
 
 def main(data):
+    """Categorize new transactions and save them to the output table."""
 
     existing = load_existing_table()
 
@@ -23,97 +24,86 @@ def main(data):
 
     print(f"{len(unprocessed_data)} new transactions need categorization.\n")
 
-    for idx, row in unprocessed_data.iterrows():
-        payee = row['payee']
-        date = row['date']
-        amount = row['amount']
+    for _, row in unprocessed_data.iterrows():
+        payee = row["payee"]
+        date = row["date"]
+        amount = row["amount"]
 
         # Look up all historical transactions (any date, any amount) for this payee
-        payee_history = existing[existing['payee'] == payee]
-        used_categories = payee_history['category'].unique()
-        used_categories = [cat for cat in used_categories if pd.notna(cat)]
+        payee_history = existing[existing["payee"] == payee]
+        used_categories = payee_history["category"].dropna().unique()
 
-        # 1) If this payee is brand new, do the normal LLM flow
         if len(used_categories) == 0:
+            # Brand new payee, get a description and let the model classify it
             print(f"🆕 New payee: '{payee}'")
             print(f"Transaction date: {date.date()} | Amount: ${amount:.2f}")
-            note = input("Describe the expense in plain English - type p+space+note for personal expense: ")
-            if note.startswith('p '):
+            note = input(
+                "Describe the expense in plain English, or prefix with 'p ' for personal: "
+            )
+            if note.startswith("p "):
                 category = "PERSONAL"
                 note = note[2:].strip()
             else:
-                category = categorize_expense(note)
+                category = categorize_expense(payee, amount, note)
 
-        # 2) If no prior category
-        if len(used_categories) == 0:
-            # Let user quickly mark as personal, or proceed to LLM
-            choice = input("Is this a personal expense? (y/n): ").strip().lower()
-            if choice == 'y':
-                category = "PERSONAL"
-                note = "Personal expense"
-            else:
-                # Normal note + LLM
-                note = input("Describe the expense in plain English or type p+space+note for personal expense: ")
-                if note.startswith('p '):
-                    category = "PERSONAL"
-                    note = note[2:].strip()
-                else:
-                    category = categorize_expense(note)
-
-        # 3) If exactly one prior category
         elif len(used_categories) == 1:
+            # Exactly one prior category
             auto_cat = used_categories[0]
             print(f"Previously, '{payee}' was always categorized as '{auto_cat}'")
-            choice = input("[y] Reuse category, [n] new LLM, or [p] personal? ").strip().lower()
+            choice = input(
+                "[y] Reuse category, [n] new LLM, or [p] personal? "
+            ).strip().lower()
 
-            if choice == 'y':
+            if choice == "y":
                 # Reuse
-                cat_rows = payee_history[payee_history['category'] == auto_cat]
-                last_note = cat_rows.iloc[-1]['note']
+                cat_rows = payee_history[payee_history["category"] == auto_cat]
+                last_note = cat_rows.iloc[-1]["note"]
                 category = auto_cat
                 note = last_note if pd.notna(last_note) else ""
-            elif choice == 'p':
+            elif choice == "p":
                 category = "PERSONAL"
                 note = "Personal expense"
             else:
                 # New LLM
                 note = input("Describe the expense in plain English: ")
-                category = categorize_expense(note)
+                category = categorize_expense(payee, amount, note)
 
-        # 4) Multiple prior categories
         else:
+            # Multiple prior categories
             print("\nWe’ve seen multiple categories for this payee in the past:")
             for i, cat in enumerate(used_categories):
                 print(f"{i}. {cat}")
-            choice = input("Pick a category index, or press [enter] for new LLM, or [p] personal: ").strip().lower()
+            choice = input(
+                "Pick a category index, or press [enter] for new LLM, or [p] personal: "
+            ).strip().lower()
 
             if choice.isdigit():
                 idx_choice = int(choice)
                 if 0 <= idx_choice < len(used_categories):
                     selected_cat = used_categories[idx_choice]
-                    cat_rows = payee_history[payee_history['category'] == selected_cat]
-                    last_note = cat_rows.iloc[-1]['note']
+                    cat_rows = payee_history[payee_history["category"] == selected_cat]
+                    last_note = cat_rows.iloc[-1]["note"]
                     category = selected_cat
                     note = last_note if pd.notna(last_note) else ""
                 else:
-                    # fallback
+                    # Fallback to model
                     note = input("Describe the expense in plain English: ")
-                    category = categorize_expense(note)
-            elif choice == 'p':
+                    category = categorize_expense(payee, amount, note)
+            elif choice == "p":
                 category = "PERSONAL"
                 note = "Personal expense"
             else:
                 # Do new LLM
                 note = input("Describe the expense in plain English: ")
-                category = categorize_expense(note)
+                category = categorize_expense(payee, amount, note)
 
-        # 5) Append the new row to existing and save
+        # Append the new row to existing and save
         new_row = {
             "payee": payee,
             "date": date,
             "amount": amount,
             "note": note,
-            "category": category
+            "category": category,
         }
         existing = pd.concat([existing, pd.DataFrame([new_row])], ignore_index=True)
         save_table(existing)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,7 +6,9 @@ from utils import load_statements
 st.title("🧾 Bookkeeping Assistant")
 
 data = load_statements()
-if not isinstance(data, type(None)):
+if data is not None:
     st.write("Data columns:", data.columns)
     st.write(data.head(10))
     app.main(data)
+else:
+    st.info("Upload bank statement CSV files to get started.")

--- a/utils.py
+++ b/utils.py
@@ -1,39 +1,65 @@
 import pandas as pd
 import streamlit as st
 
+
 def load_statements():
-    uploaded_files = st.file_uploader("Upload Bank Statements (CSV)", accept_multiple_files=True)
+    """Load one or more CSV bank statements uploaded via Streamlit."""
+
+    uploaded_files = st.file_uploader(
+        "Upload Bank Statements (CSV)", accept_multiple_files=True
+    )
     if uploaded_files:
         dfs = [pd.read_csv(f) for f in uploaded_files]
         data = pd.concat(dfs, ignore_index=True)
         st.write(f"{len(data)} rows loaded from {len(uploaded_files)} files.")
-        normed_data = normalize_bank_data(data) 
+        normed_data = normalize_bank_data(data)
         st.write(f"Columns in normalized data: {normed_data.columns}")
         return normed_data
-    else: 
-        return None
 
-def save_table(df, path='data/output_table.csv'):
+    st.info("Upload files to begin.")
+    return None
+
+
+def save_table(df, path="data/output_table.csv"):
+    """Persist the categorized transactions to disk."""
+
     df.to_csv(path, index=False)
 
-def load_existing_table(path='data/output_table.csv'):
+
+def load_existing_table(path="data/output_table.csv"):
+    """Return the existing categorized transactions table, if it exists."""
+
     try:
         return pd.read_csv(path)
     except FileNotFoundError:
-        return pd.DataFrame(columns=["payee", "date", "amount", "note", "category"])
-    
+        return pd.DataFrame(
+            columns=["payee", "date", "amount", "note", "category"]
+        )
+
+
 def normalize_bank_data(df):
+    """Normalize raw bank statement columns to the expected schema."""
+
     df.reset_index(inplace=True)
-    df.columns = ['details','date','payee','amount','type','balance','check_num','na']
-    df.drop(columns=['na','check_num'])
+    df.columns = [
+        "details",
+        "date",
+        "payee",
+        "amount",
+        "type",
+        "balance",
+        "check_num",
+        "na",
+    ]
+    df.drop(columns=["na", "check_num"], inplace=True)
 
     # Make sure required columns are present
-    for col in ['date', 'payee', 'amount']:
+    for col in ["date", "payee", "amount"]:
         if col not in df.columns:
             raise ValueError(f"Missing required column: {col}")
 
-    df['date'] = pd.to_datetime(df['date'], errors='coerce')
-    df = df.dropna(subset=['date', 'payee', 'amount'])
+    df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    df = df.dropna(subset=["date", "payee", "amount"])
 
     return df
 


### PR DESCRIPTION
## Summary
- Streamline categorization workflow and pass payee/amount context to the LLM
- Read OpenAI API key from environment and document categorize_expense helper
- Improve statement loading, normalization, and Streamlit UI messaging

## Testing
- `python -m py_compile app.py streamlit_app.py utils.py llm.py`


------
https://chatgpt.com/codex/tasks/task_e_688e66a3e748832a8ec0bb7fadb91166