### PR TITLE
Group payee transactions by account type and flag outliers

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,110 +2,136 @@ import pandas as pd
 from utils import load_existing_table, save_table
 from llm import categorize_expense
 
-def main(data):
-    """Categorize new transactions and save them to the output table."""
+
+def main(data, account_type="business"):
+    """Categorize new transactions and save them to the output table.
+
+    Parameters
+    ----------
+    data: DataFrame
+        New bank transactions to categorize.
+    account_type: str
+        Either "personal" or "business" to control default assumptions.
+    """
 
     existing = load_existing_table()
 
-    # Make sure both dataframes have the same, consistent column types
-    existing['date'] = pd.to_datetime(existing['date'], errors='coerce')
-    data['date'] = pd.to_datetime(data['date'], errors='coerce')
+    # Ensure consistent column types
+    existing["date"] = pd.to_datetime(existing["date"], errors="coerce")
+    data["date"] = pd.to_datetime(data["date"], errors="coerce")
 
-    # Mark each row with a composite key, so we don’t re-insert duplicates
-    existing['transaction_key'] = existing.apply(
+    # Mark each row with a composite key so we don’t re-insert duplicates
+    existing["transaction_key"] = existing.apply(
         lambda r: f"{r['payee']}|{r['date']}|{r['amount']}", axis=1
     )
-    data['transaction_key'] = data.apply(
+    data["transaction_key"] = data.apply(
         lambda r: f"{r['payee']}|{r['date']}|{r['amount']}", axis=1
     )
 
-    processed_keys = set(existing['transaction_key'])
-    unprocessed_data = data[~data['transaction_key'].isin(processed_keys)]
+    processed_keys = set(existing["transaction_key"])
+    unprocessed_data = data[~data["transaction_key"].isin(processed_keys)]
 
     print(f"{len(unprocessed_data)} new transactions need categorization.\n")
 
-    for _, row in unprocessed_data.iterrows():
-        payee = row["payee"]
-        date = row["date"]
-        amount = row["amount"]
-
-        # Look up all historical transactions (any date, any amount) for this payee
+    # Group new transactions by payee so we categorize once per payee
+    for payee, group in unprocessed_data.groupby("payee"):
         payee_history = existing[existing["payee"] == payee]
         used_categories = payee_history["category"].dropna().unique()
 
-        if len(used_categories) == 0:
-            # Brand new payee, get a description and let the model classify it
-            print(f"🆕 New payee: '{payee}'")
-            print(f"Transaction date: {date.date()} | Amount: ${amount:.2f}")
-            note = input(
-                "Describe the expense in plain English, or prefix with 'p ' for personal: "
-            )
-            if note.startswith("p "):
-                category = "PERSONAL"
-                note = note[2:].strip()
-            else:
-                category = categorize_expense(payee, amount, note)
-
-        elif len(used_categories) == 1:
-            # Exactly one prior category
-            auto_cat = used_categories[0]
-            print(f"Previously, '{payee}' was always categorized as '{auto_cat}'")
-            choice = input(
-                "[y] Reuse category, [n] new LLM, or [p] personal? "
-            ).strip().lower()
-
-            if choice == "y":
-                # Reuse
-                cat_rows = payee_history[payee_history["category"] == auto_cat]
-                last_note = cat_rows.iloc[-1]["note"]
-                category = auto_cat
-                note = last_note if pd.notna(last_note) else ""
-            elif choice == "p":
-                category = "PERSONAL"
-                note = "Personal expense"
-            else:
-                # New LLM
-                note = input("Describe the expense in plain English: ")
-                category = categorize_expense(payee, amount, note)
-
+        # Determine the default category for this payee based on account type
+        if account_type == "personal":
+            default_category = "PERSONAL"
+            default_note = "Personal expense"
         else:
-            # Multiple prior categories
-            print("\nWe’ve seen multiple categories for this payee in the past:")
-            for i, cat in enumerate(used_categories):
-                print(f"{i}. {cat}")
-            choice = input(
-                "Pick a category index, or press [enter] for new LLM, or [p] personal: "
-            ).strip().lower()
-
-            if choice.isdigit():
-                idx_choice = int(choice)
-                if 0 <= idx_choice < len(used_categories):
-                    selected_cat = used_categories[idx_choice]
-                    cat_rows = payee_history[payee_history["category"] == selected_cat]
-                    last_note = cat_rows.iloc[-1]["note"]
-                    category = selected_cat
-                    note = last_note if pd.notna(last_note) else ""
-                else:
-                    # Fallback to model
-                    note = input("Describe the expense in plain English: ")
-                    category = categorize_expense(payee, amount, note)
-            elif choice == "p":
-                category = "PERSONAL"
-                note = "Personal expense"
-            else:
-                # Do new LLM
+            if len(used_categories) == 0:
+                # Brand new payee, let the model classify
+                print(f"🆕 New payee: '{payee}'")
                 note = input("Describe the expense in plain English: ")
-                category = categorize_expense(payee, amount, note)
+                default_category = categorize_expense(payee, group["amount"].mean(), note)
+                default_note = note
+            elif len(used_categories) == 1:
+                auto_cat = used_categories[0]
+                print(f"Previously, '{payee}' was always categorized as '{auto_cat}'")
+                choice = input("[y] Reuse category, [n] new LLM, or [p] personal? ").strip().lower()
+                if choice == "y":
+                    cat_rows = payee_history[payee_history["category"] == auto_cat]
+                    last_note = cat_rows.iloc[-1]["note"]
+                    default_category = auto_cat
+                    default_note = last_note if pd.notna(last_note) else ""
+                elif choice == "p":
+                    default_category = "PERSONAL"
+                    default_note = "Personal expense"
+                else:
+                    note = input("Describe the expense in plain English: ")
+                    default_category = categorize_expense(payee, group["amount"].mean(), note)
+                    default_note = note
+            else:
+                print(f"\nWe’ve seen multiple categories for '{payee}' in the past:")
+                for i, cat in enumerate(used_categories):
+                    print(f"{i}. {cat}")
+                choice = input(
+                    "Pick a category index, or press [enter] for new LLM, or [p] personal: "
+                ).strip().lower()
+                if choice.isdigit():
+                    idx_choice = int(choice)
+                    if 0 <= idx_choice < len(used_categories):
+                        selected_cat = used_categories[idx_choice]
+                        cat_rows = payee_history[payee_history["category"] == selected_cat]
+                        last_note = cat_rows.iloc[-1]["note"]
+                        default_category = selected_cat
+                        default_note = last_note if pd.notna(last_note) else ""
+                    else:
+                        note = input("Describe the expense in plain English: ")
+                        default_category = categorize_expense(payee, group["amount"].mean(), note)
+                        default_note = note
+                elif choice == "p":
+                    default_category = "PERSONAL"
+                    default_note = "Personal expense"
+                else:
+                    note = input("Describe the expense in plain English: ")
+                    default_category = categorize_expense(payee, group["amount"].mean(), note)
+                    default_note = note
 
-        # Append the new row to existing and save
-        new_row = {
-            "payee": payee,
-            "date": date,
-            "amount": amount,
-            "note": note,
-            "category": category,
-        }
-        existing = pd.concat([existing, pd.DataFrame([new_row])], ignore_index=True)
-        save_table(existing)
+        # Combine historical and new amounts to detect outliers
+        amounts_history = pd.concat([payee_history["amount"], group["amount"]])
+        mean_amount = amounts_history.mean()
+        std_amount = amounts_history.std()
 
-        print(f"✅ Saved: {payee} [{category}] on {date.date()} => ${amount:.2f}\n")
+        for _, row in group.iterrows():
+            amount = row["amount"]
+            date = row["date"]
+
+            is_outlier = (
+                pd.notna(std_amount)
+                and std_amount > 0
+                and abs(amount - mean_amount) > 2 * std_amount
+            )
+
+            if is_outlier:
+                print(
+                    f"⚠️ Unusual amount for {payee}: ${amount:.2f} (mean ${mean_amount:.2f})"
+                )
+                note = input(
+                    "Describe this transaction, or prefix with 'p ' for personal: "
+                )
+                if note.startswith("p "):
+                    category = "PERSONAL"
+                    note = note[2:].strip()
+                else:
+                    category = categorize_expense(payee, amount, note)
+            else:
+                category = default_category
+                note = default_note
+
+            new_row = {
+                "payee": payee,
+                "date": date,
+                "amount": amount,
+                "note": note,
+                "category": category,
+            }
+            existing = pd.concat([existing, pd.DataFrame([new_row])], ignore_index=True)
+            save_table(existing)
+            print(
+                f"✅ Saved: {payee} [{category}] on {date.date()} => ${amount:.2f}\n"
+            )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -5,10 +5,13 @@ from utils import load_statements
 
 st.title("🧾 Bookkeeping Assistant")
 
+# Let the user specify whether the uploaded statements are personal or business
+account_type = st.selectbox("Account type", ["business", "personal"])
+
 data = load_statements()
 if data is not None:
     st.write("Data columns:", data.columns)
     st.write(data.head(10))
-    app.main(data)
+    app.main(data, account_type=account_type)
 else:
     st.info("Upload bank statement CSV files to get started.")


### PR DESCRIPTION
## Summary
- allow specifying account type in the Streamlit UI and pass it to the categorizer
- group new transactions by payee and auto-assign a default category per account type
- flag statistically unusual amounts for separate review

## Testing
- `python -m py_compile app.py streamlit_app.py utils.py llm.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e79c9f1d8832aa10fd354cd1de564