### PR TITLE
Normalize Amazon Digital payees and improve LLM categorization

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from utils import load_existing_table, save_table, normalize_payee
+from utils import load_existing_table, save_table, normalize_payee, confirm_category
 from llm import categorize_expense
 
 
@@ -127,6 +127,8 @@ def main(data, account_type="business"):
             else:
                 category = default_category
                 note = default_note
+
+            category = confirm_category(category)
 
             new_row = {
                 "payee": row["payee"],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,69 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import json
+import utils
+from llm import categorize_expense, normalize_payees
+
+
+def test_amzn_digital_normalization():
+    payee1 = 'AMZN Digital*GM3C83WE 888-802-3080 WA        09/30'
+    payee2 = 'AMZN Digital*K67VZ1R2 888-802-3080 WA        10/30'
+    assert utils.normalize_payee(payee1) == 'AMZN DIGITAL'
+    assert utils.normalize_payee(payee2) == 'AMZN DIGITAL'
+
+
+class DummyResponse:
+    def __init__(self, text):
+        self.output_text = text
+
+
+def test_llm_called_for_r_and_d(monkeypatch):
+    calls = {}
+
+    def fake_create(model, input):
+        calls["called"] = True
+        return DummyResponse("Research & Development")
+
+    monkeypatch.setattr("llm.client.responses.create", fake_create)
+
+    result = categorize_expense("AMZN Digital", 16.99, "Research & dev")
+    assert result == "Research & Development"
+    assert calls.get("called")
+
+
+def test_confirm_category_override(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "Software & Subscriptions")
+    assert (
+        utils.confirm_category("Research & Development")
+        == "Software & Subscriptions"
+    )
+
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    assert utils.confirm_category("Travel") == "Travel"
+
+
+def test_llm_normalizes_payees(monkeypatch):
+    payee1 = 'AMZN Digital*GM3C83WE 888-802-3080 WA        09/30'
+    payee2 = 'AMZN Digital*K67VZ1R2 888-802-3080 WA        10/30'
+
+    def fake_create(model, input):
+        mapping = {
+            payee1: "AMZN DIGITAL",
+            payee2: "AMZN DIGITAL",
+        }
+        return DummyResponse(json.dumps(mapping))
+
+    calls = {}
+    def wrapper(model, input):
+        calls["called"] = True
+        return fake_create(model, input)
+
+    monkeypatch.setattr("llm.client.responses.create", wrapper)
+
+    result = normalize_payees([payee1, payee2])
+    assert result[payee1] == "AMZN DIGITAL"
+    assert result[payee2] == "AMZN DIGITAL"
+    assert calls.get("called")


### PR DESCRIPTION
## Summary
- Add LLM helper to batch-normalize payee names and return canonical vendors
- Invoke the LLM-based payee normalizer when loading existing tables to collapse variants
- Test the new payee normalization workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8bdb40b0832aa740779df0dabda0