### PR TITLE
Support multiple account tables

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ from utils import (
 from llm import categorize_expense, normalize_payees as llm_normalize_payees
 
 
-def main(data):
+def main(data, account_type: str | None = None):
     """Categorize new transactions and save them to the output table.
 
     This function walks through the following flow:
@@ -31,9 +31,12 @@ def main(data):
     ----------
     data: DataFrame
         New bank transactions to categorize.
+    account_type: str | None, optional
+        If provided, read from and write to tables specific to this account
+        type (e.g., ``business`` or ``personal``).
     """
 
-    existing = load_existing_table()
+    existing = load_existing_table(account_type=account_type)
 
     # Ensure consistent column types
     existing["date"] = pd.to_datetime(existing["date"], errors="coerce")
@@ -76,11 +79,11 @@ def main(data):
         group = group.assign(note=note, category=category)
         existing = pd.concat([existing, group], ignore_index=True)
         existing = propagate_vendor_info(existing, payee, note, category)
-        save_table(existing)
+        save_table(existing, account_type=account_type)
         print(
             f"✅ Saved {len(group)} transaction(s) for '{display_payee}' as '{category}'"
         )
 
     # Once everything is categorized, update the summary table
-    save_summary_table(existing)
+    save_summary_table(existing, account_type=account_type)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,3 +99,37 @@ def test_generate_summary():
     office_total = summary.loc[summary["category"] == "Office", "total_amount"].iloc[0]
     assert meals_total == 30
     assert office_total == 30
+
+
+def test_account_type_separates_tables(monkeypatch, tmp_path):
+    monkeypatch.setattr(utils, "llm_normalize_payees", lambda payees: {p: p for p in payees})
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data").mkdir()
+
+    df_business = pd.DataFrame(
+        {
+            "payee": ["BizCo"],
+            "date": pd.to_datetime(["2024-01-01"]),
+            "amount": [100],
+            "note": [""],
+            "category": [""],
+        }
+    )
+    df_personal = pd.DataFrame(
+        {
+            "payee": ["Home"],
+            "date": pd.to_datetime(["2024-02-01"]),
+            "amount": [200],
+            "note": [""],
+            "category": [""],
+        }
+    )
+
+    utils.save_table(df_business, account_type="business")
+    utils.save_table(df_personal, account_type="personal")
+
+    loaded_business = utils.load_existing_table(account_type="business")
+    loaded_personal = utils.load_existing_table(account_type="personal")
+
+    assert loaded_business["payee"].tolist() == ["BizCo"]
+    assert loaded_personal["payee"].tolist() == ["Home"]

--- a/utils.py
+++ b/utils.py
@@ -22,14 +22,48 @@ def load_statements():
     return None
 
 
-def save_table(df, path="data/output_table.csv"):
-    """Persist the categorized transactions to disk."""
+def save_table(df, path: str | None = None, account_type: str | None = None):
+    """Persist the categorized transactions to disk.
+
+    Parameters
+    ----------
+    df:
+        Table of categorized transactions.
+    path:
+        Optional explicit path to write the table to.
+    account_type:
+        When ``path`` is not provided, use this to select a file name scoped
+        to a specific account type (e.g., ``business`` or ``personal``).
+    """
+
+    if path is None:
+        suffix = "output_table.csv"
+        if account_type:
+            path = f"data/{account_type}_{suffix}"
+        else:
+            path = f"data/{suffix}"
 
     df.to_csv(path, index=False)
 
 
-def load_existing_table(path="data/output_table.csv"):
-    """Return the existing categorized transactions table, if it exists."""
+def load_existing_table(path: str | None = None, account_type: str | None = None):
+    """Return the existing categorized transactions table, if it exists.
+
+    Parameters
+    ----------
+    path:
+        Optional explicit path to read from.
+    account_type:
+        When ``path`` is not provided, use this to select a file name scoped
+        to a specific account type (e.g., ``business`` or ``personal``).
+    """
+
+    if path is None:
+        suffix = "output_table.csv"
+        if account_type:
+            path = f"data/{account_type}_{suffix}"
+        else:
+            path = f"data/{suffix}"
 
     try:
         df = pd.read_csv(path)
@@ -160,8 +194,30 @@ def generate_summary(df: pd.DataFrame) -> pd.DataFrame:
     return summary
 
 
-def save_summary_table(df: pd.DataFrame, path: str = "data/category_summary.csv") -> None:
-    """Persist aggregate category totals to disk for a tax preparer."""
+def save_summary_table(
+    df: pd.DataFrame,
+    path: str | None = None,
+    account_type: str | None = None,
+) -> None:
+    """Persist aggregate category totals to disk for a tax preparer.
+
+    Parameters
+    ----------
+    df:
+        Categorized transaction table.
+    path:
+        Optional explicit path to write the summary to.
+    account_type:
+        When ``path`` is not provided, use this to select a file name scoped to
+        a specific account type (e.g., ``business`` or ``personal``).
+    """
+
+    if path is None:
+        suffix = "category_summary.csv"
+        if account_type:
+            path = f"data/{account_type}_{suffix}"
+        else:
+            path = f"data/{suffix}"
 
     summary = generate_summary(df)
     summary.to_csv(path, index=False)


### PR DESCRIPTION
## Summary
- allow main app to differentiate output tables via an account_type parameter
- handle account-specific file paths in utility functions
- test that personal and business tables are saved separately

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f6b8d3140832a8eadc28d303770e3