### PR TITLE
Remove numeric tokens from payee normalization

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,12 @@ def test_amzn_digital_normalization():
     assert utils.normalize_payee(payee2) == 'AMZN DIGITAL'
 
 
+def test_godaddy_normalization():
+    payee1 = 'DNH*GODADDY #1234567 480-5058877 AZ        09/30'
+    payee2 = 'DNH*GODADDY #7654321 800-9876543 AZ        10/30'
+    assert utils.normalize_payee(payee1) == utils.normalize_payee(payee2) == 'DNH*GODADDY AZ'
+
+
 class DummyResponse:
     def __init__(self, text):
         self.output_text = text

--- a/utils.py
+++ b/utils.py
@@ -109,7 +109,12 @@ def normalize_payee(payee: str) -> str:
     if payee_no_date.startswith(("AMZN DIGITAL", "AMAZON DIGITAL")):
         return "AMZN DIGITAL"
 
-    # Collapse multiple spaces for general normalization
+    # Remove ticket numbers, long digit sequences, and phone numbers
+    payee_no_date = re.sub(r"#\d+", "", payee_no_date)
+    payee_no_date = re.sub(r"\b\d{3}-\d{7}\b", "", payee_no_date)
+    payee_no_date = re.sub(r"\b\d{5,}\b", "", payee_no_date)
+
+    # Collapse multiple spaces and trim
     payee_no_date = re.sub(r"\s{2,}", " ", payee_no_date)
     return payee_no_date.strip()
 


### PR DESCRIPTION
## Summary
- Strip ticket numbers, long digit sequences, and phone numbers in `normalize_payee`
- Add regression test ensuring differing GoDaddy IDs normalize identically

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6c97e558832aa17bf2f58c51614a