### PR TITLE
Use normalized payee for user prompts

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,7 +88,7 @@ def main(data, account_type: str | None = None):
     # Prompt once per normalized vendor and amount cluster
     for payee, group in unprocessed_data.groupby("normalized_payee"):
         for sub in split_amount_clusters(group):
-            display_payee = sub.iloc[0]["payee"]
+            display_payee = payee
             print(f"\nProcessing '{display_payee}' ({len(sub)} transactions)")
 
             # Show payment statistics before requesting a description


### PR DESCRIPTION
## Summary
- display the normalized payee name instead of the raw bank string when prompting the user

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f879ee78c832abcd19da00ae91139