### PR TITLE
Improve payee normalization and personal flow

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -73,10 +73,10 @@ def load_existing_table(path: str | None = None, account_type: str | None = None
         )
 
     # Ensure the normalized_payee column exists for downstream grouping.
-    # We start by grouping on the raw payee names and then use the LLM to
-    # collapse any variants down to a canonical vendor.
+    # We start by heuristically cleaning the raw payee names and then use the
+    # LLM to collapse any remaining variants down to a canonical vendor.
     if "payee" in df.columns:
-        df["normalized_payee"] = df["payee"]
+        df["normalized_payee"] = df["payee"].apply(normalize_payee)
         mapping = llm_normalize_payees(
             df["normalized_payee"].dropna().unique().tolist()
         )


### PR DESCRIPTION
## Summary
- Clean payee names with a heuristic `normalize_payee` step before LLM mapping, preventing duplicates caused by trailing dates.
- For personal accounts, automatically categorize transactions as **Personal** when the user presses enter, skipping the LLM.

## Testing
- `uv sync`
- `.venv/bin/pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689158941040832a9468e795c36a4b68